### PR TITLE
Unbreak tests by pinning `responses`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,10 +3,14 @@ envlist = py39, flake8, black
 
 [testenv]
 deps =
-    freezegun
-    pytest
-    pytest-mock
-    moto
+    freezegun==1.1.0
+    moto==2.3.1
+    pytest==6.2.5
+    pytest-mock==3.6.1
+    # XXX: Version 0.17.0 breaks our tests in mysterious ways, so pin
+    #      it to the previous version. We don't use this library
+    #      directly, but it's a sub-dependency of moto.
+    responses==0.16.0
     -rrequirements.txt
 commands =
     python -m tests.setup.populate_local_keycloak
@@ -36,7 +40,6 @@ deps =
     black
 commands =
     black --check .
-
 
 [flake8]
 # https://github.com/ambv/black/blob/master/.flake8


### PR DESCRIPTION
The newest 0.17.0 version of the `repsonses` library breaks our tests in mysterious ways, so pin it to the previous 0.16.0 version. We don't use this library directly, but it's a sub-dependency of `moto`.

Also pin the top-level test dependencies to make the version cocktail more predictable.