### PR TITLE
T#293 Open up and extend existing team endpoints

### DIFF
--- a/models/models.py
+++ b/models/models.py
@@ -36,6 +36,7 @@ class User(BaseModel):
 class Team(BaseModel):
     id: str
     name: str
+    is_member: bool
     attributes: Union[dict, None] = None
 
     @validator("name", pre=True)

--- a/tests/setup/local_keycloak_config.py
+++ b/tests/setup/local_keycloak_config.py
@@ -47,6 +47,7 @@ team2member = "team2member"
 team1 = "team1"
 team2 = "team2"
 team3 = "team3"
+teams = [team1, team2, team3]
 nonteamgroup = "group1"
 
 user1 = {

--- a/tests/teams_integrations_test.py
+++ b/tests/teams_integrations_test.py
@@ -1,6 +1,4 @@
 import unittest
-from itertools import groupby
-from operator import itemgetter
 
 import pytest
 
@@ -80,11 +78,7 @@ def test_list_teams_is_member(mock_client):
     )
     assert response.status_code == 200
 
-    teams = {
-        name: list(team)[0]
-        for name, team in groupby(response.json(), itemgetter("name"))
-    }
-
+    teams = {team["name"]: team for team in response.json()}
     assert teams["team1"]["is_member"]
     assert not teams["team2"]["is_member"]
     assert teams["team3"]["is_member"]


### PR DESCRIPTION
`get_teams`:
- Include all teams (not just the caller's own teams) when the new query parameter `include` = `all`.
- Include team membership status in all returned teams.

`get_team`:
- Allow lookup up teams without being a member (mirroring `get_team_by_name`).
- Include team membership status.

`get_team_by_name`:
- Include team membership status.