### PR TITLE
Increase timeout for `check-users`

### DIFF
--- a/serverless.yaml
+++ b/serverless.yaml
@@ -69,7 +69,7 @@ functions:
     handler: jobs.monitor.check_users
     events:
       - schedule: cron(0 * * * ? *)
-    timeout: 30
+    timeout: 60
 
 plugins:
   - serverless-plugin-git-variables


### PR DESCRIPTION
The `check-users` job times out sporadically. Increase the timeout to see if that helps.

Sprinkle on some logging too, to make it easier for us to see where time is spent.