### PR TITLE
Don't error on unknown user when listing teams

### DIFF
--- a/dataplatform_keycloak/teams_client.py
+++ b/dataplatform_keycloak/teams_client.py
@@ -106,6 +106,11 @@ class TeamsClient:
         try:
             user_id = self.teams_admin_client.get_user_id(username)
             user_groups = self.teams_admin_client.get_user_groups(user_id)
+        except KeycloakGetError as e:
+            if e.response_code == 404:
+                return []
+            log_keycloak_error(e)
+            raise TeamsServerError
         except KeycloakError as e:
             log_keycloak_error(e)
             raise TeamsServerError


### PR DESCRIPTION
Don't error out (500 response) in the teams listing endpoint when provided an unknown user name.