### PR TITLE
Relax the user check frequency

### DIFF
--- a/serverless.yaml
+++ b/serverless.yaml
@@ -68,7 +68,7 @@ functions:
   check-users:
     handler: jobs.monitor.check_users
     events:
-      - schedule: cron(0 * * * ? *)
+      - schedule: cron(1 0 * * ? *)
     timeout: 60
 
 plugins:


### PR DESCRIPTION
Backups are only produced daily, so relax the user check frequency from 24 times a day to 1 to avoid flooding the alerts channel.