### PR TITLE
Read the Slack webhook at runtime

### DIFF
--- a/jobs/monitor.py
+++ b/jobs/monitor.py
@@ -4,16 +4,13 @@ import os
 import requests
 from aws_xray_sdk.core import patch_all, xray_recorder
 from okdata.aws.logging import logging_wrapper, log_add, log_exception
+from okdata.aws.ssm import get_secret
 
 from dataplatform_keycloak.teams_client import TeamsClient
 from jobs.backup import load_latest_backup
 
 logger = logging.getLogger()
 logger.setLevel(os.environ.get("LOG_LEVEL", logging.INFO))
-
-SLACK_PERMISSION_API_ALERTS_WEBHOOK_URL = os.environ[
-    "SLACK_PERMISSION_API_ALERTS_WEBHOOK_URL"
-]
 
 patch_all()
 
@@ -74,7 +71,8 @@ def check_users(event, context):
 def slack_notify(message):
     try:
         response = requests.post(
-            SLACK_PERMISSION_API_ALERTS_WEBHOOK_URL, json={"text": message}
+            get_secret("/dataplatform/slack/permission-api-slack-webhook"),
+            json={"text": message},
         )
         response.raise_for_status()
     except requests.RequestException as e:

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,9 @@ attrs==21.4.0
 aws-xray-sdk==2.9.0
     # via okdata-permission-api (setup.py)
 boto3==1.24.11
-    # via okdata-permission-api (setup.py)
+    # via
+    #   okdata-aws
+    #   okdata-permission-api (setup.py)
 botocore==1.27.11
     # via
     #   aws-xray-sdk
@@ -44,11 +46,11 @@ jsonschema==4.6.0
     # via okdata-sdk
 mangum==0.15.0
     # via okdata-permission-api (setup.py)
-okdata-aws==1.0.1
+okdata-aws==2.1.0
     # via okdata-permission-api (setup.py)
 okdata-resource-auth==0.1.4
     # via okdata-permission-api (setup.py)
-okdata-sdk==2.0.0
+okdata-sdk==3.1.0
     # via okdata-aws
 pyasn1==0.4.8
     # via
@@ -108,6 +110,7 @@ typing-extensions==4.9.0
 urllib3==1.26.18
     # via
     #   botocore
+    #   okdata-sdk
     #   python-keycloak
     #   requests
 wrapt==1.14.1

--- a/serverless.yaml
+++ b/serverless.yaml
@@ -40,7 +40,6 @@ provider:
     ROOT_PATH: "/okdata-permission-api"
     LOG_LEVEL: INFO
     BACKUP_BUCKET_NAME: ${self:custom.backupBucket.${self:provider.stage}, self:custom.backupBucket.dev}
-    SLACK_PERMISSION_API_ALERTS_WEBHOOK_URL: ${ssm:/dataplatform/slack/permission-api-slack-webhook}
 
 package:
   patterns:

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
         "boto3",
         "fastapi>=0.109.2",
         "mangum>=0.10.0",
-        "okdata-aws>=1.0.1,<2.0.0",
+        "okdata-aws>=2.1,<3",
         "okdata-resource-auth>=0.1.4",
         "pydantic[email]~=1.10.0",
         "pyjwt",

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,6 @@ setenv =
     CLIENT_ID = okdata-permission-api
     SERVICE_NAME = okdata-permission-api
     BACKUP_BUCKET_NAME = backup-bucket
-    SLACK_PERMISSION_API_ALERTS_WEBHOOK_URL = http://hooks.slack.arpa/services/123
 
 [testenv:flake8]
 skip_install = true


### PR DESCRIPTION
Don't hardcode the Slack webhook in the Lambda environment, fetch it from SSM at runtime instead.