### PR TITLE
Add shortcut keyword for granting all permissions

### DIFF
--- a/models/scope.py
+++ b/models/scope.py
@@ -37,6 +37,14 @@ def all_scopes_for_type(resource_type):
     return [f"{resource_type}:{permission}" for permission in _SCOPES[resource_type]]
 
 
+def resource_type(resource_name):
+    """Return the namespaced resource type of `resource_name`.
+
+    I.e. "namespace:type" from "namespace:type:name".
+    """
+    return ":".join(resource_name.split(":")[:2])
+
+
 def scope_permission(scope):
     """Return the permission part of `scope`.
 

--- a/tests/models/test_scope.py
+++ b/tests/models/test_scope.py
@@ -2,7 +2,12 @@ from unittest.mock import patch
 
 import pytest
 
-from models.scope import all_scopes, all_scopes_for_type, scope_permission
+from models.scope import (
+    all_scopes,
+    all_scopes_for_type,
+    resource_type,
+    scope_permission,
+)
 
 
 _SCOPES = {
@@ -22,6 +27,10 @@ def test_all_scopes_for_type():
     assert all_scopes_for_type("okdata:bar") == ["okdata:bar:p3"]
     with pytest.raises(ValueError):
         all_scopes_for_type("okdata:baz")
+
+
+def test_resource_type():
+    assert resource_type("namespace:type:permission") == "namespace:type"
 
 
 def test_scope_permission():


### PR DESCRIPTION
Add a shortcut keyword "__all__" on the `update_permission` method for granting all available permissions on a resource to a user.