### PR TITLE
Switch Keycloak Docker image provider

### DIFF
--- a/keycloak-compose.yaml
+++ b/keycloak-compose.yaml
@@ -3,7 +3,7 @@
 version: "3"
 services:
   keycloak:
-    image: jboss/keycloak:15.1.1
+    image: quay.io/keycloak/keycloak:15.1.1
     ports:
       - "35789:8080"
     environment:


### PR DESCRIPTION
Switch the provider of the Keycloak Docker image that is used in the tests. The Keycloak people have apparently moved from Docker Hub to Quay.