### PR TITLE
Increase timeout for permission backup job

### DIFF
--- a/serverless.yaml
+++ b/serverless.yaml
@@ -73,7 +73,7 @@ functions:
         - jobs.backup.backup_permissions
     events:
       - schedule: cron(0 0 * * ? *)
-    timeout: 30
+    timeout: 60
   check-users:
     image:
       name: okdata-permission-api


### PR DESCRIPTION
The normal running time is pretty close to the previous 30 seconds limit, and the task times out occasionally. Let's double the timeout.